### PR TITLE
Trivial renames to support fplll-5.2.1

### DIFF
--- a/mmap/mmap_gen.hpp
+++ b/mmap/mmap_gen.hpp
@@ -240,8 +240,8 @@ void public_parameters_generate::generate()
 	mpz_realloc2(m.get_mpz_t(), 2 * (params.eta - 3));
 	for (unsigned i = 0; i < params.n; i++)
 	{
-		mpz_set(Mat[i](0, 0).getData(), one.get_mpz_t());
-		mpz_set(Mat[i](1, 1).getData(), m.get_mpz_t());
+		mpz_set(Mat[i](0, 0).get_data(), one.get_mpz_t());
+		mpz_set(Mat[i](1, 1).get_data(), m.get_mpz_t());
 	}
 
 	// p_zt
@@ -430,12 +430,12 @@ void public_parameters_generate::generate_p_zt_coeff(unsigned i)
 	u >>= (params.xi - (2 * (params.eta - 3)));
 	mpz_realloc2(u.get_mpz_t(), 2 * (params.eta - 3));
 
-	mpz_set(Mat[i](0, 1).getData(), u.get_mpz_t());
-	fplll::lllReduction(Mat[i]);
+	mpz_set(Mat[i](0, 1).get_data(), u.get_mpz_t());
+	fplll::lll_reduction(Mat[i]);
 
 	_Pragma(STRINGIFY(omp critical))
 	{
-		p_zt += h[i] * Q * mpz_class(Mat[i](0, 0).getData());
+		p_zt += h[i] * Q * mpz_class(Mat[i](0, 0).get_data());
 	}
 
 	Mat[i].clear();


### PR DESCRIPTION
This patch renames appearances of getData (get_data) and lllReduction (lll_reduction) in order to work with a current version of fplll.

Caveat: I am not familiar with either library; this was a naive change, just enough to permit compilation as suggested by the compiler.  Clearly there might be some otehr reason why an older version of fplll might be required.